### PR TITLE
feat: thinking 기본값 OFF — 요청별 enable_thinking으로 제어

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ openclaw, OpenAI SDK 등 기존 클라이언트를 그대로 연결해 완전히
 
 | 모델 | 실행 명령 | 메모리 | 속도 | 특징 |
 |------|----------|------:|-----:|------|
-| **Qwen3.6-27B-6bit** (기본) | `./llm-server.sh` | ~23GB | ~45~55 tok/s³ | 멀티모달(이미지), Thinking 기본 ON, preserve_thinking 지원, mlx-vlm 런타임 |
+| **Qwen3.6-27B-6bit** (기본) | `./llm-server.sh` | ~23GB | ~45~55 tok/s³ | 멀티모달(이미지), Thinking 기본 OFF, 요청별 ON 가능, preserve_thinking 지원, mlx-vlm 런타임 |
 | **SuperGemma4-26B uncensored-v2** | `./llm-server.sh supergemma4` | ~13GB | 46 tok/s | 무검열(파인튜닝), 툴콜·한국어·코드 강화, 텍스트 전용 |
 | **SuperGemma4-26B abliterated-multimodal** | 직접 모델 ID 지정¹ | ~15GB | ~49 tok/s | 무검열(EGA), 이미지+텍스트 입력 지원 |
 
@@ -28,7 +28,7 @@ openclaw, OpenAI SDK 등 기존 클라이언트를 그대로 연결해 완전히
 | 기능 | Qwen3.6-27B (기본) | SuperGemma4 uncensored-v2 | SuperGemma4 abliterated-multimodal |
 |------|:-----------------:|:------------------------:|:---------------------------------:|
 | 컨텍스트 프로필 (1m/262k) | ✅ | ❌ (128K 고정) | ❌ (256K 고정) |
-| Thinking 모드 (`enable_thinking`) | ✅ (기본 ON) | ❌ | ❌ |
+| Thinking 모드 (`enable_thinking`) | ✅ (기본 OFF) | ❌ | ❌ |
 | 대화형 채팅 (`llm-chat.sh`) | ✅ | ❌ | ❌ |
 | 이미지 입력 (멀티모달) | ✅ | ❌ | ✅ |
 | 영상 입력 | ❌ | ❌ | ❌ |
@@ -45,7 +45,7 @@ openclaw, OpenAI SDK 등 기존 클라이언트를 그대로 연결해 완전히
 | **생성 속도** | ~103 tok/s | ~45~55 tok/s³ | ~46 tok/s |
 | **컨텍스트** | 262K / 1M (YaRN) | 262K / 1M (YaRN) | 128K 고정 |
 | **이미지 입력** | ❌ | ✅ | ❌ |
-| **Thinking 모드** | ✅ | ✅ **(기본 ON)** | ❌ |
+| **Thinking 모드** | ✅ | ✅ **(기본 OFF)** | ❌ |
 | **검열 해제** | ❌ | ❌ | ✅ (파인튜닝) |
 | **한국어/코딩 강화** | 기본 | 기본 | ✅ (파인튜닝) |
 | **툴 콜 강화** | 기본 | 기본 | ✅ (2배↑) |
@@ -54,7 +54,7 @@ openclaw, OpenAI SDK 등 기존 클라이언트를 그대로 연결해 완전히
 | **SWE-bench Verified** | - | **77.2** | - |
 | **GPQA Diamond** | - | **87.8** | 82.3 |
 
-Qwen3.6은 파라미터가 줄었지만 Dense 아키텍처로 전환 + 멀티모달 추가 + Thinking 기본 ON. 속도는 MoE였던 3.5보다 느리지만 이미지·Thinking 지원이 핵심 차이.
+Qwen3.6은 파라미터가 줄었지만 Dense 아키텍처로 전환 + 멀티모달 추가 + Thinking 기본 OFF, 요청별 ON 가능. 속도는 MoE였던 3.5보다 느리지만 이미지·Thinking 지원이 핵심 차이.
 
 ---
 
@@ -85,7 +85,7 @@ cd local-llm
 
 | # | 모델 | 메모리 | 특징 |
 |:-:|------|------:|------|
-| 1 | **Qwen3.6-27B-6bit** ⭐ | ~23GB | VLM, 텍스트+이미지, Thinking 기본 ON |
+| 1 | **Qwen3.6-27B-6bit** ⭐ | ~23GB | VLM, 텍스트+이미지, Thinking 기본 OFF |
 | 2 | **SuperGemma4-26B** (무검열) | ~16GB | 무검열 보조 모델 (텍스트 전용) |
 | 3 | 직접 입력 | - | Hugging Face 모델 ID |
 
@@ -213,7 +213,7 @@ OpenAI 호환 API 서버. FastAPI + mlx_vlm Python API로 직접 추론.
 
 ```bash
 # Qwen3.6-27B (기본)
-./llm-server.sh              # 262K 컨텍스트, Thinking ON (기본)
+./llm-server.sh              # 262K 컨텍스트, Thinking OFF (기본)
 ./llm-server.sh 1m           # 1M 컨텍스트 (YaRN)
 ./llm-server.sh 262k 9090    # 포트 지정
 
@@ -274,11 +274,7 @@ curl http://localhost:8080/v1/chat/completions \
 #### 요청별 Thinking 제어
 
 ```bash
-# 기본값 ON → 이 요청만 OFF
-curl http://localhost:8080/v1/chat/completions \
-  -d '{"messages":[{"role":"user","content":"안녕!"}],"enable_thinking":false}'
-
-# thinking 블록 응답에 포함 (기본은 제거)
+# Thinking 활성화 (기본 OFF → 이 요청만 ON)
 curl http://localhost:8080/v1/chat/completions \
   -d '{"messages":[{"role":"user","content":"123*456=?"}],"enable_thinking":true,"preserve_thinking":true,"max_tokens":500}'
 ```
@@ -299,7 +295,7 @@ curl http://localhost:8080/v1/chat/completions \
 | `presence_penalty` | float | 0 | 존재 패널티 (OpenAI 호환용, 모델에 전달되지 않음) |
 | `frequency_penalty` | float | 0 | 빈도 패널티 (OpenAI 호환용, 모델에 전달되지 않음) |
 | `repetition_penalty` | float | null | 반복 패널티 (파싱됨, 현재 모델에 전달되지 않음) |
-| `enable_thinking` | bool | true | Thinking 모드 (기본 ON, Qwen3.6-27B 지원) |
+| `enable_thinking` | bool | false | Thinking 모드 (기본 OFF, 요청별 ON 가능, Qwen3.6-27B 지원) |
 | `preserve_thinking` | bool | false | true 시 `<think>...</think>` 블록 응답에 포함 |
 
 #### 웹 UI 연동
@@ -401,7 +397,7 @@ YaRN(Yet another RoPE extensioN)으로 위치 인코딩을 스케일링.
 
 > Qwen3.6-27B 전용. SuperGemma4에서 `enable_thinking`을 보내도 오류는 없지만 무시됩니다. 서버가 자동 감지 처리.
 
-Qwen3.6-27B는 Thinking 기본 ON (DEFAULT_THINKING=True). `preserve_thinking=true` 요청 시 `<think>...</think>` 블록이 응답에 포함됩니다. 기본값(false)은 thinking 블록을 제거하고 최종 답변만 반환합니다.
+Qwen3.6-27B는 Thinking 기본 OFF (DEFAULT_THINKING=False). 요청 시 enable_thinking=true로 ON 가능. `preserve_thinking=true` 요청 시 `<think>...</think>` 블록이 응답에 포함됩니다. 기본값(false)은 thinking 블록을 제거하고 최종 답변만 반환합니다.
 
 ### Thinking ON
 
@@ -420,7 +416,7 @@ Qwen3.6-27B는 Thinking 기본 ON (DEFAULT_THINKING=True). `preserve_thinking=tr
 | 모드 | 방법 | 동작 |
 |------|------|:---:|
 | `llm-chat.sh` (대화형) | 프롬프트에 `/no_think` 추가 | O |
-| `llm-server.sh` (API) | 기본값 Thinking ON | O |
+| `llm-server.sh` (API) | 기본값 Thinking OFF | O |
 | `llm-server.sh --no-think` (API) | --no-think 명시 (Thinking OFF) | O |
 | API 요청 `enable_thinking` | **요청별 제어 가능** | **O** |
 | API 요청 `preserve_thinking` | **thinking 블록 포함 여부** | **O** |

--- a/llm-api-server.py
+++ b/llm-api-server.py
@@ -41,7 +41,7 @@ gpu_semaphore = None
 pending = 0
 MAX_QUEUE = 5
 LOG_DIR = ""
-DEFAULT_THINKING = True
+DEFAULT_THINKING = False
 
 
 # ── 로깅 ─────────────────────────────────────────
@@ -456,8 +456,8 @@ def main():
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("--max-queue", type=int, default=5)
-    parser.add_argument("--think", action=argparse.BooleanOptionalAction, default=True,
-                        help="Thinking ON/OFF (기본값: ON, --no-think으로 비활성화)")
+    parser.add_argument("--think", action=argparse.BooleanOptionalAction, default=False,
+                        help="Thinking ON/OFF (기본값: OFF, --think으로 활성화)")
     args = parser.parse_args()
 
     model_id = args.model

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -384,10 +384,10 @@ class TestStripThinking:
 
 # ── preserve_thinking / DEFAULT_THINKING 통합 테스트 ─────────────────────────
 class TestPreserveThinking:
-    def test_default_thinking_is_true_at_module_level(self):
-        """CORE-05: DEFAULT_THINKING 모듈 레벨 기본값이 True이다
-        (autouse fixture가 False로 override하기 전의 실제 모듈 초기값 검증)"""
-        assert _MODULE_DEFAULT_THINKING_AT_LOAD is True
+    def test_default_thinking_is_false_at_module_level(self):
+        """CORE-05: DEFAULT_THINKING 모듈 레벨 기본값이 False이다
+        (autouse fixture가 override하기 전의 실제 모듈 초기값 검증)"""
+        assert _MODULE_DEFAULT_THINKING_AT_LOAD is False
 
     def test_preserve_thinking_false_strips_think_block(self, client):
         """CORE-06: preserve_thinking=False(기본)일 때 응답 content에서 <think> 블록이 제거된다"""


### PR DESCRIPTION
## 변경 사항

Qwen3.6-27B에서 thinking이 기본 ON이라 응답 속도가 느린 문제 해결.

### 핵심 변경
- **기본값 OFF**: `DEFAULT_THINKING = False`, `--think` argparse default=False
- **요청별 제어 유지**: `enable_thinking: true` 파라미터로 특정 요청만 thinking ON 가능
- **테스트 수정**: `test_default_thinking_is_false_at_module_level` (assert False)
- **README 업데이트**: "기본 ON" → "기본 OFF" 8곳 반영, curl 예시 정리

### 사용법

```bash
# 기본 (thinking OFF — 빠름)
./llm-server.sh

# 서버 레벨 thinking ON
./llm-server.sh --think

# 요청별 thinking ON
curl -X POST http://localhost:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"123*456?"}],"enable_thinking":true}'
```

### 테스트
- pytest 38 passed, 0 failed ✅

## Summary by Sourcery

Set Qwen3.6-27B thinking mode to be disabled by default while keeping per-request control via enable_thinking.

Enhancements:
- Change server-level DEFAULT_THINKING and --think CLI flag to default to Thinking OFF for Qwen3.6-27B, with optional opt-in.
- Align API parameter defaults so enable_thinking is false by default while preserving per-request override behavior.

Documentation:
- Update README to describe Thinking as OFF by default, adjust usage examples, and clarify per-request enable_thinking behavior.

Tests:
- Update core thinking-related test to assert a default OFF module-level thinking configuration.