### PR TITLE
fix: strip_thinking max_tokens 잘림 시 thinking 내용 노출 방지 (closes #14)

### DIFF
--- a/llm-api-server.py
+++ b/llm-api-server.py
@@ -212,14 +212,18 @@ def get_prompt_preview(messages):
     return ""
 
 
-def strip_thinking(text):
+def strip_thinking(text, enable_thinking=False):
     """<think>...</think> 블록 제거 — preserve_thinking=False일 때만 호출 (CORE-06)"""
     import re
     # Qwen3.6-27B: chat template이 <think>를 프롬프트 prefix로 주입하므로
     # 생성 텍스트에는 </think> 끝 태그만 나옴 — split으로 이후 텍스트 추출.
-    # </think>가 없으면(max_tokens 초과로 잘린 경우) 기존 정규식 폴백.
     if "</think>" in text:
         return text.split("</think>", 1)[1].strip()
+    if enable_thinking:
+        # enable_thinking=True인데 </think> 없음 → max_tokens 초과로 잘린 것
+        # thinking 내용 노출 방지 (finish_reason=length로 클라이언트가 인지, issue #14)
+        return ""
+    # enable_thinking=False: thinking 블록이 없는 정상 응답 → 원문 반환
     return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
 
 
@@ -332,7 +336,7 @@ def _run_inference_inner(params):
 
     # preserve_thinking=False일 때만 <think> 블록 제거 (per D-19)
     if not params.get("preserve_thinking"):
-        full_text = strip_thinking(full_text)
+        full_text = strip_thinking(full_text, enable_thinking=params.get("enable_thinking", False))
 
     if images:
         prompt_cache_state.cache = None
@@ -564,12 +568,13 @@ def _stream_response(req_id, params, ip, start, last_msg):
                             if after:
                                 yield f"data: {json.dumps(make_chunk(req_id, params['model'], {'content': after}))}\n\n"
 
-                # </think>가 끝내 안 나온 경우 (thinking 없는 응답이거나 max_tokens 초과로 잘림)
-                # 버퍼 전체를 한 번에 yield해 regression 방지
-                if not thinking_done and think_buf:
+                # </think>가 끝내 안 나온 경우:
+                # - enable_thinking=False: thinking 없는 정상 응답 → 버퍼 전체 yield
+                # - enable_thinking=True: max_tokens 초과로 잘린 것 → thinking 내용 노출 방지 (issue #14)
+                if not thinking_done and think_buf and not params.get("enable_thinking"):
                     yield f"data: {json.dumps(make_chunk(req_id, params['model'], {'content': think_buf}))}\n\n"
 
-                full_text = strip_thinking(full_text)
+                full_text = strip_thinking(full_text, enable_thinking=params.get("enable_thinking", False))
 
                 # 최종 청크
                 yield f"data: {json.dumps(make_chunk(req_id, params['model'], {}, finish_reason))}\n\n"

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -388,6 +388,18 @@ class TestStripThinking:
         result = _REAL_STRIP_THINKING(input_text)
         assert result == "일반 텍스트 응답"
 
+    def test_strip_thinking_truncated_without_close_tag(self):
+        """issue #14: enable_thinking=True인데 </think> 없이 잘린 경우 빈 문자열 반환 (thinking 내용 노출 방지)"""
+        truncated = "추론 과정이 잘린 텍스트"
+        result = _REAL_STRIP_THINKING(truncated, enable_thinking=True)
+        assert result == ""
+
+    def test_strip_thinking_truncated_enable_thinking_false(self):
+        """issue #14: enable_thinking=False이면 </think> 없어도 원문 그대로 반환"""
+        normal_response = "thinking 없는 정상 응답"
+        result = _REAL_STRIP_THINKING(normal_response, enable_thinking=False)
+        assert result == "thinking 없는 정상 응답"
+
 
 # ── preserve_thinking / DEFAULT_THINKING 통합 테스트 ─────────────────────────
 class TestPreserveThinking:


### PR DESCRIPTION
## 변경 내용

### 문제
`strip_thinking`이 `enable_thinking=True`일 때 `max_tokens` 초과로 `</think>`가 생성되기 전에 잘리면, thinking 내용 전체가 `content`로 노출되는 버그.

이 텍스트가 rolling context에 assistant 메시지로 쌓이면 다음 라운드 prefill이 급증함 (보고된 증상: Round 7에서 605→1012 토큰 점프).

### 수정

**`strip_thinking(text, enable_thinking=False)`** — `enable_thinking` 파라미터 추가
- `enable_thinking=True`이고 `</think>` 없음 → `""" 반환 (thinking 내용 노출 방지)
- `enable_thinking=False` → 기존 동작 유지 (원문 그대로 반환)

**스트리밍** — `think_buf` yield 조건 수정
- `enable_thinking=True`일 때 `</think>` 없이 루프 종료 → `think_buf` yield 하지 않음

> 클라이언트는 `finish_reason: length`로 잘림을 인지해야 함.

### 테스트
- 기존 35개 통과
- 케이스 2개 추가: `enable_thinking=True` 잘림 → `""`, `enable_thinking=False` → 원문

## Summary by Sourcery

Prevent internal thinking content from being exposed when responses are truncated before the </think> tag while preserving existing behavior when thinking is disabled.

Bug Fixes:
- Ensure strip_thinking returns an empty string when enable_thinking is true and the closing </think> tag is missing to avoid leaking thinking content.
- Avoid yielding buffered thinking content in streaming responses when enable_thinking is true and no closing </think> tag appears.

Tests:
- Add regression tests covering truncated outputs with and without enable_thinking to verify correct strip_thinking behavior.